### PR TITLE
[Feat] 초기 Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/config/SwaggerConfig.java
+++ b/src/main/java/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("SafetyGPS API")
+                .description("사용자 안전 귀갓길 제공 서비스 API 문서")
+                .version("1.0.0");
+    }
+}


### PR DESCRIPTION
API 문서화를 위해 Swagger 설정을 추가했습니다.

- Swagger UI 접속 경로 설정
- 기본 API 정보(title, description, version) 등록
- Spring Boot 프로젝트에서 자동 API 문서화 가능하도록 구성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI/Swagger UI for API documentation. SafetyGPS API documentation is now accessible through an interactive interface (v1.0.0), enabling users to explore endpoints, view parameters and response schemas, and test API functionality directly without external tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->